### PR TITLE
Add memcmp, Sapphire sbuild.toml

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -14,6 +14,7 @@ extern char *strncpy(char *dest, const char *src, size_t n);
 // extern char *strcat(char *dest, const char *src);
 // extern char *strncat(char *dest, const char *src, size_t n);
 
+extern int memcmp(const void *s1, const void *s2, size_t n);
 extern int strcmp(const char *s1, const char *s2);
 extern int strncmp(const char *s1, const char *s2, size_t n);
 

--- a/sbuild.toml
+++ b/sbuild.toml
@@ -1,0 +1,9 @@
+library_root = true
+name = "ali"
+libtype = "C"
+
+ignore_source_regex = [
+  "(^|_)test.c$"
+]
+
+object_remove_globs = []

--- a/src/string.c
+++ b/src/string.c
@@ -52,6 +52,11 @@ char *strncpy(char *dest, const char *src, size_t n)
 // char *strcat(char *dest, const char *src);
 // char *strncat(char *dest, const char *src, size_t n);
 
+int memcmp(const void *s1, const void *s2, size_t n)
+{
+    return strncmp((const char*)s1, (const char*)s2, n);
+}
+
 int strcmp(const char *s1, const char *s2)
 {
     size_t s1_len = strlen(s1),


### PR DESCRIPTION
Adds a `memcmp()` function (which just wraps `strncmp()` as they're the same thing)

This also adds a `sbuild.toml` to enable compiling as part of the [sapphire](https://github.com/0x52a1/sapphire) build process. 